### PR TITLE
Add custom replay id to reproduce issue

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -124,7 +124,9 @@ function subscribe(client, topicName, schema) {
     //Once the system has received the events == to numReqested then the stream will end.
     const subscribeRequest = {
         topicName,
-        numRequested: PUB_SUB_EVENT_RECEIVE_LIMIT
+        numRequested: PUB_SUB_EVENT_RECEIVE_LIMIT,
+        replayId: "12907414",
+        replayPreset: 2
     };
     subscription.write(subscribeRequest);
     console.log(


### PR DESCRIPTION
Testing the new GRPC communication with salesforce we have notified an issue trying to connect from a previous Replay Id. Using the previous communication everything worked fine.

This is the code we have added in order to reproduce the issue in our environments.